### PR TITLE
Wait for the server to be up when running Cypress in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,3 +15,4 @@ jobs:
         with:
           build: npm run build
           start: npx serve@latest out
+          wait-on: 'http://localhost:3000'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added a feature to wait for `http://localhost:3000` before proceeding in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->